### PR TITLE
Add Container Id property

### DIFF
--- a/rhea/rhea.html
+++ b/rhea/rhea.html
@@ -191,7 +191,7 @@
         paletteLabel: 'amqp-recv.',
         oneditprepare: function() {
             $('#node-input-prefetch').spinner({min:0});
-            
+
             // if dynamic is set, the address MUST NOT be used (AMQP 1.0 spec)
             $('#node-input-dynamic').on('change', function() {
                 $('#node-input-address').prop('disabled', this.checked)
@@ -295,6 +295,10 @@
         <label for="node-config-input-password"><i class="icon-tasks"></i> Password</label>
         <input type="text" id="node-config-input-password" placeholder="password">
     </div>
+    <div class="form-row">
+          <label for="node-config-input-clientId"><i class="icon-tag"></i> clientId</label>
+          <input type="text" id="node-config-input-clientId" placeholder="clientId">
+      </div>
 	<div class="form-row">
         <label for="node-config-input-name"><i class="icon-tag"></i> Name</label>
         <input type="text" id="node-config-input-name" placeholder="name">
@@ -309,6 +313,7 @@
           port: { value: '', required: true, validate: RED.validators.number() } ,
           username: { value: '' },
           password: { value: '' },
+          clientId: { value: '' },
           name: { value: '' }
         },
 		label: function() {

--- a/rhea/rhea.html
+++ b/rhea/rhea.html
@@ -296,8 +296,8 @@
         <input type="text" id="node-config-input-password" placeholder="password">
     </div>
     <div class="form-row">
-          <label for="node-config-input-clientId"><i class="icon-tag"></i> clientId</label>
-          <input type="text" id="node-config-input-clientId" placeholder="Leave blank for auto generated">
+          <label for="node-config-input-container_id"><i class="icon-tag"></i> Container Id</label>
+          <input type="text" id="node-config-input-container_id" placeholder="Leave blank for auto generated">
       </div>
 	<div class="form-row">
         <label for="node-config-input-name"><i class="icon-tag"></i> Name</label>
@@ -313,7 +313,7 @@
           port: { value: '', required: true, validate: RED.validators.number() } ,
           username: { value: '' },
           password: { value: '' },
-          clientId: { value: '' },
+          container_id: { value: '' },
           name: { value: '' }
         },
 		label: function() {

--- a/rhea/rhea.html
+++ b/rhea/rhea.html
@@ -297,7 +297,7 @@
     </div>
     <div class="form-row">
           <label for="node-config-input-clientId"><i class="icon-tag"></i> clientId</label>
-          <input type="text" id="node-config-input-clientId" placeholder="clientId">
+          <input type="text" id="node-config-input-clientId" placeholder="Leave blank for auto generated">
       </div>
 	<div class="form-row">
         <label for="node-config-input-name"><i class="icon-tag"></i> Name</label>

--- a/rhea/rhea.js
+++ b/rhea/rhea.js
@@ -30,7 +30,7 @@ module.exports = function(RED) {
         this.port = n.port;
         this.username = n.username;
         this.password = n.password;
-        this.container_id = n.clientId;
+        this.container_id = n.container_id;
 
         // build options for connection
         var options = { host: this.host, port: this.port};

--- a/rhea/rhea.js
+++ b/rhea/rhea.js
@@ -30,14 +30,20 @@ module.exports = function(RED) {
         this.port = n.port;
         this.username = n.username;
         this.password = n.password;
+        this.container_id = n.clientId;
 
         // build options for connection
-        var options = { host: this.host, port: this.port, container_id: container.generate_uuid() };
+        var options = { host: this.host, port: this.port};
         if (this.username) {
             options.username = this.username;
         }
         if (this.password) {
             options.password = this.password;
+        }
+        if (this.container_id) {
+            options.container_id = this.container_id;
+        } else {
+            options.container_id = "node-red-rhea-" + container.generate_uuid();
         }
 
         var node = this;


### PR DESCRIPTION
For an AMQP client, it is useful to configure clientId,
we provide a new property input, if blank value solution generates one for it.

